### PR TITLE
refactor: remove unused limits_rows variable

### DIFF
--- a/excel_export.py
+++ b/excel_export.py
@@ -154,7 +154,6 @@ def export_schedule_excel(supabase, tz_name="Europe/Moscow", week_monday: dateti
         # Один лист "График"
         sheet_name = "График"
         start_row = 1
-        limits_rows = []
 
         # Сначала — сводка по лимитам вверху
         # Структура: День недели | Роль | Лимит


### PR DESCRIPTION
## Summary
- remove unused limits_rows variable from Excel export

## Testing
- `python -m py_compile excel_export.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac4385decc832ba35e450355adb972